### PR TITLE
GregorianCalendar Locales issue

### DIFF
--- a/src/main/java/com/moneychanger/ui/custom/DatePicker.java
+++ b/src/main/java/com/moneychanger/ui/custom/DatePicker.java
@@ -496,6 +496,7 @@ public final class DatePicker extends JPanel {
                 selectedDate.get(Calendar.YEAR),
                 selectedDate.get(Calendar.MONTH),
                 1);
+        c.setMinimalDaysInFirstWeek(1);// fix for different locales
 
         // figure out the maximum number of days in the month
         final int maxDay = calculateDaysInMonth(c);


### PR DESCRIPTION
Calendar.getMinimalDaysInFirstWeek() for different locales returns different values
## Because of that DatePicker's calculateCalendar() results in outOfBounds while iterating over weeks

more changes needed
